### PR TITLE
feat: 为所有微服务添加完整的结构化日志系统

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ COPY . .
 # 编译指定的服务
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd ./cmd/${SERVICE_NAME} && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /workspace/bin/${SERVICE_NAME} .
-
+    CGO_ENABLED=0 GOOS=linux go build -gcflags="all=-trimpath=${PWD}" -ldflags="-s -w" -o /workspace/bin/${SERVICE_NAME} ./cmd/${SERVICE_NAME}/main.go
 # ---- Runtime Stage ----
 FROM alpine:latest
 ARG SERVICE_NAME

--- a/cmd/notification-service/internal/handler/grpc_handler.go
+++ b/cmd/notification-service/internal/handler/grpc_handler.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"context"
-	"log"
+	"log/slog"
+
 	pb "qahub/api/proto/notification"
+	pkglog "qahub/pkg/log"
 	"qahub/notification-service/internal/service"
 	"qahub/pkg/pagination"
 
@@ -23,11 +25,26 @@ func NewNotificationGrpcServer(notificationService service.NotificationService) 
 }
 
 func (s *NotificationGrpcServer) GetNotifications(ctx context.Context, req *pb.GetNotificationsRequest) (*pb.GetNotificationsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("获取通知请求",
+		slog.Int64("user_id", req.UserId),
+	)
+
 	limit, offset := pagination.LimitOffsetFromRequest(req)
 	notifications, err := s.notificationService.GetNotifications(ctx, req.UserId, limit, offset)
 	if err != nil {
+		logger.Error("获取通知失败",
+			slog.Int64("user_id", req.UserId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("获取通知成功",
+		slog.Int64("user_id", req.UserId),
+		slog.Int("count", len(notifications)),
+	)
 
 	var pbNotifications []*pb.Notification
 	for _, n := range notifications {
@@ -50,30 +67,82 @@ func (s *NotificationGrpcServer) GetNotifications(ctx context.Context, req *pb.G
 }
 
 func (s *NotificationGrpcServer) MarkAsRead(ctx context.Context, req *pb.MarkAsReadRequest) (*pb.MarkAsReadResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("标记通知为已读请求",
+		slog.Int64("user_id", req.GetUserId()),
+		slog.Bool("mark_all", req.GetMarkAll()),
+		slog.Int("notification_count", len(req.GetNotificationIds())),
+	)
+
 	ModifiedCount, err := s.notificationService.MarkNotificationsAsRead(ctx, req.GetUserId(), req.GetNotificationIds(), req.GetMarkAll())
 	if err != nil {
+		logger.Error("标记通知为已读失败",
+			slog.Int64("user_id", req.GetUserId()),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("标记通知为已读成功",
+		slog.Int64("user_id", req.GetUserId()),
+		slog.Int64("modified_count", ModifiedCount),
+	)
+
 	return &pb.MarkAsReadResponse{
 		ModifiedCount: ModifiedCount,
 	}, nil
 }
 
 func (s *NotificationGrpcServer) DeleteNotification(ctx context.Context, req *pb.DeleteNotificationRequest) (*pb.DeleteNotificationResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("删除通知请求",
+		slog.Int64("user_id", req.GetUserId()),
+		slog.String("notification_id", req.GetNotificationId()),
+	)
+
 	err := s.notificationService.DeleteNotification(ctx, req.GetUserId(), req.GetNotificationId())
 	if err != nil {
+		logger.Error("删除通知失败",
+			slog.Int64("user_id", req.GetUserId()),
+			slog.String("notification_id", req.GetNotificationId()),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除通知成功",
+		slog.Int64("user_id", req.GetUserId()),
+		slog.String("notification_id", req.GetNotificationId()),
+	)
+
 	return &pb.DeleteNotificationResponse{
 		NotificationId: req.GetNotificationId(),
 	}, nil
 }
 
 func (s *NotificationGrpcServer) GetUnreadCount(ctx context.Context, req *pb.GetUnreadCountRequest) (*pb.GetUnreadCountResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("获取未读通知数请求",
+		slog.Int64("user_id", req.GetUserId()),
+	)
+
 	count, err := s.notificationService.GetUnreadCount(ctx, req.GetUserId())
 	if err != nil {
+		logger.Error("获取未读通知数失败",
+			slog.Int64("user_id", req.GetUserId()),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("获取未读通知数成功",
+		slog.Int64("user_id", req.GetUserId()),
+		slog.Int64("unread_count", count),
+	)
+
 	return &pb.GetUnreadCountResponse{
 		UnreadCount: count,
 	}, nil
@@ -81,8 +150,12 @@ func (s *NotificationGrpcServer) GetUnreadCount(ctx context.Context, req *pb.Get
 
 // SubscribeNotifications 实现服务端流式推送实时通知
 func (s *NotificationGrpcServer) SubscribeNotifications(req *pb.SubscribeNotificationsRequest, stream pb.NotificationService_SubscribeNotificationsServer) error {
+	logger := pkglog.FromContext(stream.Context())
 	userID := req.GetUserId()
-	log.Printf("User %d subscribing to notifications stream", userID)
+
+	logger.Info("用户订阅通知流",
+		slog.Int64("user_id", userID),
+	)
 
 	// 创建流客户端
 	streamClient := &service.StreamClient{
@@ -99,10 +172,15 @@ func (s *NotificationGrpcServer) SubscribeNotifications(req *pb.SubscribeNotific
 	// 保持连接直到客户端断开或上下文取消
 	select {
 	case <-stream.Context().Done():
-		log.Printf("User %d stream context done: %v", userID, stream.Context().Err())
+		logger.Info("通知流上下文完成",
+			slog.Int64("user_id", userID),
+			slog.String("error", stream.Context().Err().Error()),
+		)
 		return stream.Context().Err()
 	case <-streamClient.Done:
-		log.Printf("User %d stream client closed", userID)
+		logger.Info("通知流客户端关闭",
+			slog.Int64("user_id", userID),
+		)
 		return nil
 	}
 }

--- a/cmd/qa-service/internal/handler/grpc_handler.go
+++ b/cmd/qa-service/internal/handler/grpc_handler.go
@@ -2,9 +2,10 @@ package handler
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	pb "qahub/api/proto/qa"
 	"qahub/pkg/auth"
+	pkglog "qahub/pkg/log"
 	"qahub/pkg/pagination"
 	"qahub/qa-service/internal/service"
 
@@ -28,15 +29,35 @@ func NewQAGrpcServer(svc service.QAService) *QAGrpcServer {
 }
 
 func (s *QAGrpcServer) CreateQuestion(ctx context.Context, req *pb.CreateQuestionRequest) (*pb.QuestionResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("创建问题请求",
+		slog.String("title", req.Title),
+	)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("创建问题失败：无法从context获取用户信息")
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
 	question, err := s.qaService.CreateQuestion(ctx, req.Title, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("创建问题失败",
+			slog.Int64("user_id", identity.UserID),
+			slog.String("title", req.Title),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("创建问题成功",
+		slog.Int64("question_id", question.ID),
+		slog.Int64("user_id", identity.UserID),
+		slog.String("title", question.Title),
+	)
+
 	return &pb.QuestionResponse{
 		Id:        question.ID,
 		Title:     question.Title,
@@ -48,10 +69,26 @@ func (s *QAGrpcServer) CreateQuestion(ctx context.Context, req *pb.CreateQuestio
 }
 
 func (s *QAGrpcServer) GetQuestion(ctx context.Context, req *pb.GetQuestionRequest) (*pb.QuestionResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("获取问题请求",
+		slog.Int64("question_id", req.Id),
+	)
+
 	question, err := s.qaService.GetQuestion(ctx, req.Id)
 	if err != nil {
+		logger.Error("获取问题失败",
+			slog.Int64("question_id", req.Id),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("获取问题成功",
+		slog.Int64("question_id", req.Id),
+		slog.String("title", question.Title),
+	)
+
 	return &pb.QuestionResponse{
 		Id:          question.ID,
 		Title:       question.Title,
@@ -65,12 +102,28 @@ func (s *QAGrpcServer) GetQuestion(ctx context.Context, req *pb.GetQuestionReque
 }
 
 func (s *QAGrpcServer) ListQuestions(ctx context.Context, req *pb.ListQuestionsRequest) (*pb.ListQuestionsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	page, pageSize := pagination.NormalizePageAndSize(req)
+	logger.Info("列出问题请求",
+		slog.Int64("page", page),
+		slog.Any("page_size", pageSize),
+	)
+
 	questions, count, err := s.qaService.ListQuestions(ctx, page, pageSize)
 	if err != nil {
+		logger.Error("列出问题失败",
+			slog.Int64("page", page),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
-	log.Println("Fetched questions:", questions)
+
+	logger.Info("列出问题成功",
+		slog.Int64("total_count", count),
+		slog.Int("returned_count", len(questions)),
+	)
+
 	var pbQuestions []*pb.QuestionResponse
 	for _, q := range questions {
 		pbQuestions = append(pbQuestions, &pb.QuestionResponse{
@@ -91,15 +144,38 @@ func (s *QAGrpcServer) ListQuestions(ctx context.Context, req *pb.ListQuestionsR
 }
 
 func (s *QAGrpcServer) UpdateQuestion(ctx context.Context, req *pb.UpdateQuestionRequest) (*pb.QuestionResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("更新问题失败：无法从context获取用户信息",
+			slog.Int64("question_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("更新问题请求",
+		slog.Int64("question_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+		slog.String("title", req.Title),
+	)
+
 	question, err := s.qaService.UpdateQuestion(ctx, req.Id, req.Title, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("更新问题失败",
+			slog.Int64("question_id", req.Id),
+			slog.Int64("user_id", identity.UserID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("更新问题成功",
+		slog.Int64("question_id", question.ID),
+		slog.String("title", question.Title),
+	)
+
 	return &pb.QuestionResponse{
 		Id:        question.ID,
 		Title:     question.Title,
@@ -111,28 +187,71 @@ func (s *QAGrpcServer) UpdateQuestion(ctx context.Context, req *pb.UpdateQuestio
 }
 
 func (s *QAGrpcServer) DeleteQuestion(ctx context.Context, req *pb.DeleteQuestionRequest) (*emptypb.Empty, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("删除问题失败：无法从context获取用户信息",
+			slog.Int64("question_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("删除问题请求",
+		slog.Int64("question_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	err := s.qaService.DeleteQuestion(ctx, req.Id, identity.UserID)
 	if err != nil {
+		logger.Error("删除问题失败",
+			slog.Int64("question_id", req.Id),
+			slog.Int64("user_id", identity.UserID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除问题成功",
+		slog.Int64("question_id", req.Id),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 
 func (s *QAGrpcServer) CreateAnswer(ctx context.Context, req *pb.CreateAnswerRequest) (*pb.AnswerResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("创建回答失败：无法从context获取用户信息",
+			slog.Int64("question_id", req.QuestionId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("创建回答请求",
+		slog.Int64("question_id", req.QuestionId),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	answer, err := s.qaService.CreateAnswer(ctx, req.QuestionId, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("创建回答失败",
+			slog.Int64("question_id", req.QuestionId),
+			slog.Int64("user_id", identity.UserID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("创建回答成功",
+		slog.Int64("answer_id", answer.ID),
+		slog.Int64("question_id", answer.QuestionID),
+	)
+
 	return &pb.AnswerResponse{
 		Id:          answer.ID,
 		QuestionId:  answer.QuestionID,
@@ -145,15 +264,37 @@ func (s *QAGrpcServer) CreateAnswer(ctx context.Context, req *pb.CreateAnswerReq
 }
 
 func (s *QAGrpcServer) ListAnswers(ctx context.Context, req *pb.ListAnswersRequest) (*pb.ListAnswersResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("列出回答失败：无法从context获取用户信息",
+			slog.Int64("question_id", req.QuestionId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
 	page, pageSize := pagination.NormalizePageAndSize(req)
+	logger.Info("列出回答请求",
+		slog.Int64("question_id", req.QuestionId),
+		slog.Int64("page", page),
+	)
+
 	answers, count, err := s.qaService.ListAnswers(ctx, req.QuestionId, page, pageSize, identity.UserID)
 	if err != nil {
+		logger.Error("列出回答失败",
+			slog.Int64("question_id", req.QuestionId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("列出回答成功",
+		slog.Int64("question_id", req.QuestionId),
+		slog.Int64("total_count", count),
+		slog.Int("returned_count", len(answers)),
+	)
+
 	var pbAnswers []*pb.AnswerResponse
 	for _, a := range answers {
 		pbAnswers = append(pbAnswers, &pb.AnswerResponse{
@@ -175,15 +316,35 @@ func (s *QAGrpcServer) ListAnswers(ctx context.Context, req *pb.ListAnswersReque
 }
 
 func (s *QAGrpcServer) UpdateAnswer(ctx context.Context, req *pb.UpdateAnswerRequest) (*pb.AnswerResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("更新回答失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("更新回答请求",
+		slog.Int64("answer_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	answer, err := s.qaService.UpdateAnswer(ctx, req.Id, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("更新回答失败",
+			slog.Int64("answer_id", req.Id),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("更新回答成功",
+		slog.Int64("answer_id", answer.ID),
+	)
+
 	return &pb.AnswerResponse{
 		Id:          answer.ID,
 		QuestionId:  answer.QuestionID,
@@ -196,54 +357,135 @@ func (s *QAGrpcServer) UpdateAnswer(ctx context.Context, req *pb.UpdateAnswerReq
 }
 
 func (s *QAGrpcServer) DeleteAnswer(ctx context.Context, req *pb.DeleteAnswerRequest) (*emptypb.Empty, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("删除回答失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("删除回答请求",
+		slog.Int64("answer_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	err := s.qaService.DeleteAnswer(ctx, req.Id, identity.UserID)
 	if err != nil {
+		logger.Error("删除回答失败",
+			slog.Int64("answer_id", req.Id),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除回答成功",
+		slog.Int64("answer_id", req.Id),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 
 func (s *QAGrpcServer) UpvoteAnswer(ctx context.Context, req *pb.UpvoteAnswerRequest) (*emptypb.Empty, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("点赞回答失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.AnswerId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("点赞回答请求",
+		slog.Int64("answer_id", req.AnswerId),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	err := s.qaService.UpvoteAnswer(ctx, req.AnswerId, identity.UserID)
 	if err != nil {
+		logger.Error("点赞回答失败",
+			slog.Int64("answer_id", req.AnswerId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("点赞回答成功",
+		slog.Int64("answer_id", req.AnswerId),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 
 func (s *QAGrpcServer) DownvoteAnswer(ctx context.Context, req *pb.DownvoteAnswerRequest) (*emptypb.Empty, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("取消点赞回答失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.AnswerId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("取消点赞回答请求",
+		slog.Int64("answer_id", req.AnswerId),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	err := s.qaService.DownvoteAnswer(ctx, req.AnswerId, identity.UserID)
 	if err != nil {
+		logger.Error("取消点赞回答失败",
+			slog.Int64("answer_id", req.AnswerId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("取消点赞回答成功",
+		slog.Int64("answer_id", req.AnswerId),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 
 func (s *QAGrpcServer) CreateComment(ctx context.Context, req *pb.CreateCommentRequest) (*pb.CommentResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("创建评论失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.AnswerId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("创建评论请求",
+		slog.Int64("answer_id", req.AnswerId),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	comment, err := s.qaService.CreateComment(ctx, req.AnswerId, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("创建评论失败",
+			slog.Int64("answer_id", req.AnswerId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("创建评论成功",
+		slog.Int64("comment_id", comment.ID),
+		slog.Int64("answer_id", comment.AnswerID),
+	)
+
 	return &pb.CommentResponse{
 		Id:        comment.ID,
 		AnswerId:  comment.AnswerID,
@@ -255,16 +497,37 @@ func (s *QAGrpcServer) CreateComment(ctx context.Context, req *pb.CreateCommentR
 }
 
 func (s *QAGrpcServer) ListComments(ctx context.Context, req *pb.ListCommentsRequest) (*pb.ListCommentsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("列出评论失败：无法从context获取用户信息",
+			slog.Int64("answer_id", req.AnswerId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
 	_ = identity // 目前未使用身份信息，但保留以备将来使用
+
 	page, pageSize := pagination.NormalizePageAndSize(req)
+	logger.Info("列出评论请求",
+		slog.Int64("answer_id", req.AnswerId),
+		slog.Int64("page", page),
+	)
+
 	comments, count, err := s.qaService.ListComments(ctx, req.AnswerId, page, pageSize)
 	if err != nil {
+		logger.Error("列出评论失败",
+			slog.Int64("answer_id", req.AnswerId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("列出评论成功",
+		slog.Int64("answer_id", req.AnswerId),
+		slog.Int64("total_count", count),
+	)
+
 	var pbComments []*pb.CommentResponse
 	for _, c := range comments {
 		pbComments = append(pbComments, &pb.CommentResponse{
@@ -284,15 +547,35 @@ func (s *QAGrpcServer) ListComments(ctx context.Context, req *pb.ListCommentsReq
 }
 
 func (s *QAGrpcServer) UpdateComment(ctx context.Context, req *pb.UpdateCommentRequest) (*pb.CommentResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("更新评论失败：无法从context获取用户信息",
+			slog.Int64("comment_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("更新评论请求",
+		slog.Int64("comment_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	comment, err := s.qaService.UpdateComment(ctx, req.Id, req.Content, identity.UserID)
 	if err != nil {
+		logger.Error("更新评论失败",
+			slog.Int64("comment_id", req.Id),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("更新评论成功",
+		slog.Int64("comment_id", comment.ID),
+	)
+
 	return &pb.CommentResponse{
 		Id:        comment.ID,
 		AnswerId:  comment.AnswerID,
@@ -304,15 +587,35 @@ func (s *QAGrpcServer) UpdateComment(ctx context.Context, req *pb.UpdateCommentR
 }
 
 func (s *QAGrpcServer) DeleteComment(ctx context.Context, req *pb.DeleteCommentRequest) (*emptypb.Empty, error) {
+	logger := pkglog.FromContext(ctx)
+
 	//从context中获取用户信息
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
+		logger.Error("删除评论失败：无法从context获取用户信息",
+			slog.Int64("comment_id", req.Id),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
+
+	logger.Info("删除评论请求",
+		slog.Int64("comment_id", req.Id),
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	err := s.qaService.DeleteComment(ctx, req.Id, identity.UserID)
 	if err != nil {
+		logger.Error("删除评论失败",
+			slog.Int64("comment_id", req.Id),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除评论成功",
+		slog.Int64("comment_id", req.Id),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 

--- a/cmd/qa-service/internal/service/answer_service.go
+++ b/cmd/qa-service/internal/service/answer_service.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"qahub/pkg/auth"
+	"qahub/pkg/log"
 	"qahub/pkg/messaging"
 	"qahub/pkg/pagination"
 	"qahub/qa-service/internal/dto"
@@ -14,6 +16,8 @@ import (
 )
 
 func (s *qaService) CreateAnswer(ctx context.Context, questionID int64, content string, userID int64) (*model.Answer, error) {
+	logger := log.FromContext(ctx)
+	
 	answer := &model.Answer{
 		QuestionID: questionID,
 		Content:    content,
@@ -23,13 +27,28 @@ func (s *qaService) CreateAnswer(ctx context.Context, questionID int64, content 
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
 		// 如果无法获取用户信息，可以根据业务逻辑决定是返回错误还是继续
+		logger.Error("用户身份不在context中",
+			slog.Int64("question_id", questionID),
+			slog.Int64("user_id", userID),
+		)
 		return nil, errors.New("user identity not found in context")
 	}
 	answerID, err := s.store.CreateAnswer(ctx, answer)
 	if err != nil {
+		logger.Error("创建回答失败",
+			slog.Int64("question_id", questionID),
+			slog.Int64("user_id", userID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
 	answer.ID = answerID
+
+	logger.Info("回答创建成功",
+		slog.Int64("answer_id", answerID),
+		slog.Int64("question_id", questionID),
+		slog.Int64("user_id", userID),
+	)
 
 	// 发布回答创建事件
 	go func(senderUsername string, newAnswer model.Answer) {
@@ -121,35 +140,82 @@ func (s *qaService) ListAnswers(ctx context.Context, questionID int64, page int6
 }
 
 func (s *qaService) UpdateAnswer(ctx context.Context, answerID int64, content string, userID int64) (*model.Answer, error) {
+	logger := log.FromContext(ctx)
+	
 	answer, err := s.store.GetAnswerByID(ctx, answerID)
 	if err != nil {
+		logger.Error("获取回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
 	if answer.UserID != userID {
+		logger.Warn("无权限修改回答",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+			slog.Int64("owner_id", answer.UserID),
+		)
 		return nil, errors.New("无权限修改该回答")
 	}
 	answer.Content = content
 	if err := s.store.UpdateAnswer(ctx, answer); err != nil {
+		logger.Error("更新回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+	
+	logger.Info("回答更新成功",
+		slog.Int64("answer_id", answerID),
+		slog.Int64("user_id", userID),
+	)
 	// TODO: 发布回答更新事件
 	return answer, nil
 }
 
 func (s *qaService) DeleteAnswer(ctx context.Context, answerID, userID int64) error {
+	logger := log.FromContext(ctx)
+	
 	answer, err := s.store.GetAnswerByID(ctx, answerID)
 	if err != nil {
+		logger.Error("获取回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 	if answer.UserID != userID {
+		logger.Warn("无权限删除回答",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+			slog.Int64("owner_id", answer.UserID),
+		)
 		return errors.New("无权限删除该回答")
 	}
+	
+	err = s.store.DeleteAnswer(ctx, answerID)
+	if err != nil {
+		logger.Error("删除回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Info("回答删除成功",
+		slog.Int64("answer_id", answerID),
+		slog.Int64("user_id", userID),
+	)
 	// TODO: 发布回答删除事件
-	return s.store.DeleteAnswer(ctx, answerID)
+	return nil
 }
 
 func (s *qaService) UpvoteAnswer(ctx context.Context, answerID, userID int64) error {
-	return s.store.ExecTx(ctx, func(tx store.QAStore) error {
+	logger := log.FromContext(ctx)
+	
+	err := s.store.ExecTx(ctx, func(tx store.QAStore) error {
 		err := tx.CreateAnswerVote(ctx, answerID, userID, true)
 		if err != nil {
 			return err
@@ -160,10 +226,27 @@ func (s *qaService) UpvoteAnswer(ctx context.Context, answerID, userID int64) er
 		}
 		return nil
 	})
+	
+	if err != nil {
+		logger.Error("点赞回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Debug("回答被点赞",
+		slog.Int64("answer_id", answerID),
+		slog.Int64("user_id", userID),
+	)
+	return nil
 }
 
 func (s *qaService) DownvoteAnswer(ctx context.Context, answerID, userID int64) error {
-	return s.store.ExecTx(ctx, func(tx store.QAStore) error {
+	logger := log.FromContext(ctx)
+	
+	err := s.store.ExecTx(ctx, func(tx store.QAStore) error {
 		err := tx.DeleteAnswerVote(ctx, answerID, userID)
 		if err != nil {
 			return err
@@ -174,6 +257,21 @@ func (s *qaService) DownvoteAnswer(ctx context.Context, answerID, userID int64) 
 		}
 		return nil
 	})
+	
+	if err != nil {
+		logger.Error("取消点赞回答失败",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Debug("取消对回答的点赞",
+		slog.Int64("answer_id", answerID),
+		slog.Int64("user_id", userID),
+	)
+	return nil
 }
 
 func (s *qaService) CountVotes(ctx context.Context, answerID int64) (int64, error) {

--- a/cmd/qa-service/internal/service/comment_service.go
+++ b/cmd/qa-service/internal/service/comment_service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"qahub/pkg/auth"
+	"qahub/pkg/log"
 	"qahub/pkg/messaging"
 	"qahub/pkg/pagination"
 	"qahub/qa-service/internal/dto"
@@ -15,6 +16,8 @@ import (
 
 // CreateComment 创建一个新评论
 func (s *qaService) CreateComment(ctx context.Context, answerID int64, content string, userID int64) (*model.Comment, error) {
+	logger := log.FromContext(ctx)
+	
 	comment := &model.Comment{
 		AnswerID: answerID,
 		Content:  content,
@@ -25,14 +28,29 @@ func (s *qaService) CreateComment(ctx context.Context, answerID int64, content s
 	identity, ok := auth.FromContext(ctx)
 	if !ok {
 		// 如果无法获取用户信息，可以根据业务逻辑决定是返回错误还是继续
+		logger.Error("用户身份不在context中",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+		)
 		return nil, errors.New("user identity not found in context")
 	}
 
 	commentID, err := s.store.CreateComment(ctx, comment)
 	if err != nil {
+		logger.Error("创建评论失败",
+			slog.Int64("answer_id", answerID),
+			slog.Int64("user_id", userID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
 	comment.ID = commentID
+
+	logger.Info("评论创建成功",
+		slog.Int64("comment_id", commentID),
+		slog.Int64("answer_id", answerID),
+		slog.Int64("user_id", userID),
+	)
 
 	// 启动后台协程发布通知事件
 	go func(senderUsername string, newComment model.Comment) {
@@ -43,7 +61,10 @@ func (s *qaService) CreateComment(ctx context.Context, answerID int64, content s
 		answer, err := s.store.GetAnswerByID(notifyCtx, newComment.AnswerID)
 		if err != nil {
 			// 在后台任务中，错误应该被记录下来，而不是被忽略
-			log.Printf("error getting answer by id: %v", err)
+			logger.Error("后台任务：获取答案失败",
+				slog.Int64("answer_id", newComment.AnswerID),
+				slog.String("error", err.Error()),
+			)
 			return
 		}
 
@@ -116,28 +137,73 @@ func (s *qaService) ListComments(ctx context.Context, answerID int64, page int64
 
 // UpdateComment 修改评论，只有评论的创建者可以修改
 func (s *qaService) UpdateComment(ctx context.Context, commentID int64, content string, userID int64) (*model.Comment, error) {
+	logger := log.FromContext(ctx)
+	
 	comment, err := s.store.GetCommentByID(ctx, commentID)
 	if err != nil {
+		logger.Error("获取评论失败",
+			slog.Int64("comment_id", commentID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
 	if comment.UserID != userID {
+		logger.Warn("无权限修改评论",
+			slog.Int64("comment_id", commentID),
+			slog.Int64("user_id", userID),
+			slog.Int64("owner_id", comment.UserID),
+		)
 		return nil, errors.New("无权限修改该评论")
 	}
 	comment.Content = content
 	if err := s.store.UpdateComment(ctx, comment); err != nil {
+		logger.Error("更新评论失败",
+			slog.Int64("comment_id", commentID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+	
+	logger.Info("评论更新成功",
+		slog.Int64("comment_id", commentID),
+		slog.Int64("user_id", userID),
+	)
 	return comment, nil
 }
 
 // DeleteComment 删除评论，只有评论的创建者可以删除
 func (s *qaService) DeleteComment(ctx context.Context, commentID, userID int64) error {
+	logger := log.FromContext(ctx)
+	
 	comment, err := s.store.GetCommentByID(ctx, commentID)
 	if err != nil {
+		logger.Error("获取评论失败",
+			slog.Int64("comment_id", commentID),
+			slog.String("error", err.Error()),
+		)
 		return err
 	}
 	if comment.UserID != userID {
+		logger.Warn("无权限删除评论",
+			slog.Int64("comment_id", commentID),
+			slog.Int64("user_id", userID),
+			slog.Int64("owner_id", comment.UserID),
+		)
 		return errors.New("无权限删除该评论")
 	}
-	return s.store.DeleteComment(ctx, commentID)
+	
+	err = s.store.DeleteComment(ctx, commentID)
+	if err != nil {
+		logger.Error("删除评论失败",
+			slog.Int64("comment_id", commentID),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Info("评论删除成功",
+		slog.Int64("comment_id", commentID),
+		slog.Int64("user_id", userID),
+	)
+	return nil
 }

--- a/cmd/qa-service/main.go
+++ b/cmd/qa-service/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"os"
 	"qahub/pkg/clients"
 	"qahub/pkg/config"
@@ -22,34 +23,60 @@ import (
 func main() {
 	// 加载配置
 	if err := config.Init("configs"); err != nil {
+		log.Fatalf("配置加载失败: %v", err)
 		os.Exit(1)
 	}
 
 	// 初始化日志
 	logpkg.InitLogger(&config.Conf.Log)
+	logger := slog.Default()
 
 	serviceName := "qa.QAService"
+	logger.Info("问答服务启动中...",
+		slog.String("service", "qa-service"),
+		slog.String("grpc_port", config.Conf.Services.QAService.GrpcPort),
+	)
+
 	// 初始化数据库连接
+	logger.Info("初始化 MySQL 连接...")
 	db, err := database.NewMySQLConnection(config.Conf.MySQL)
 	if err != nil {
+		logger.Error("MySQL 连接失败",
+			slog.String("error", err.Error()),
+		)
 		os.Exit(1)
 	}
 	defer util.Cleanup("MySQL connection", db.Close)
+	logger.Info("MySQL 连接成功")
 
 	// 初始化 Kafka 生产者
+	logger.Info("初始化 Kafka 生产者...")
 	kafkaProducer := messaging.NewKafkaProducer(config.Conf.Kafka)
 	defer util.Cleanup("Kafka producer", kafkaProducer.Close)
+	logger.Info("Kafka 生产者初始化成功")
 
 	// 依赖注入：初始化 store, service, handler
 	qaStore := store.NewQAStore(db)
 	qaService := service.NewQAService(qaStore, kafkaProducer, &config.Conf)
 	qaHandler := handler.NewQAGrpcServer(qaService)
+
 	// 初始化 user-service 的客户端连接
+	logger.Info("连接到 user-service...",
+		slog.String("endpoint", config.Conf.Services.Gateway.UserServiceEndpoint),
+	)
 	userClient, err := clients.NewUserServiceClient(config.Conf.Services.Gateway.UserServiceEndpoint)
 	if err != nil {
+		logger.Error("连接 user-service 失败",
+			slog.String("error", err.Error()),
+		)
 		log.Fatalf("无法连接到 user-service: %v", err)
 	}
+	logger.Info("user-service 连接成功")
+
 	// 启动 gRPC 服务器
+	logger.Info("初始化 gRPC 服务器...",
+		slog.String("service_name", serviceName),
+	)
 	serverOpts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			interceptor.LogUnaryServerInterceptor(),
@@ -62,6 +89,10 @@ func main() {
 	healthUpdater := grpcSrv.HealthServer()
 	health.SetHealthChecks(healthUpdater, serviceName,
 		kafkaProducer, qaStore)
+
+	logger.Info("问答服务准备就绪，开始监听请求",
+		slog.String("grpc_port", config.Conf.Services.QAService.GrpcPort),
+	)
 
 	grpcSrv.Run(func(s *grpc.Server) {
 		qaHandler.RegisterServer(s)

--- a/cmd/search-service/internal/handler/grpc_handler.go
+++ b/cmd/search-service/internal/handler/grpc_handler.go
@@ -2,7 +2,10 @@ package handler
 
 import (
 	"context"
+	"log/slog"
+
 	pb "qahub/api/proto/search"
+	pkglog "qahub/pkg/log"
 	"qahub/search-service/internal/service"
 
 	"google.golang.org/grpc"
@@ -19,10 +22,25 @@ func NewSearchServer(s service.SearchService) *SearchGrpcServer {
 }
 
 func (h *SearchGrpcServer) SearchQuestions(ctx context.Context, req *pb.SearchQuestionsRequest) (*pb.SearchQuestionsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("搜索问题请求",
+		slog.String("query", req.Query),
+	)
+
 	results, err := h.service.SearchQuestions(ctx, req.Query)
 	if err != nil {
+		logger.Error("搜索问题失败",
+			slog.String("query", req.Query),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("搜索问题成功",
+		slog.String("query", req.Query),
+		slog.Int("result_count", len(results)),
+	)
 
 	// 将结果转换为 gRPC 响应格式
 	resp := &pb.SearchQuestionsResponse{
@@ -44,10 +62,20 @@ func (h *SearchGrpcServer) SearchQuestions(ctx context.Context, req *pb.SearchQu
 }
 
 func (h *SearchGrpcServer) IndexAllQuestions(ctx context.Context, req *pb.IndexAllQuestionsRequest) (*pb.IndexAllQuestionsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("索引所有问题请求")
+
 	err := h.service.IndexAllQuestions(ctx)
 	if err != nil {
+		logger.Error("索引所有问题失败",
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("索引所有问题成功")
+
 	return &pb.IndexAllQuestionsResponse{
 		Message:      "成功索引所有问题",
 		IndexedCount: 0, // TODO: 返回实际索引的问题数量
@@ -55,10 +83,20 @@ func (h *SearchGrpcServer) IndexAllQuestions(ctx context.Context, req *pb.IndexA
 }
 
 func (h *SearchGrpcServer) DeleteIndexAllQuestions(ctx context.Context, req *pb.DeleteIndexAllQuestionsRequest) (*pb.DeleteIndexAllQuestionsResponse, error) {
+	logger := pkglog.FromContext(ctx)
+
+	logger.Info("删除所有问题索引请求")
+
 	err := h.service.DeleteIndexAllQuestions(ctx)
 	if err != nil {
+		logger.Error("删除所有问题索引失败",
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除所有问题索引成功")
+
 	return &pb.DeleteIndexAllQuestionsResponse{
 		Message: "成功删除所有问题索引",
 	}, nil

--- a/cmd/search-service/internal/service/search_service.go
+++ b/cmd/search-service/internal/service/search_service.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"log/slog"
 
+	"qahub/pkg/log"
 	"qahub/search-service/internal/store"
 
 	"qahub/pkg/messaging"
@@ -33,15 +35,52 @@ func NewSearchService(s store.SearchStore) *searchService {
 
 // SearchQuestions 调用 store 层执行搜索
 func (s *searchService) SearchQuestions(ctx context.Context, query string) ([]messaging.QuestionPayload, error) {
-	return s.store.SearchQuestions(ctx, query)
+	logger := log.FromContext(ctx)
+	
+	results, err := s.store.SearchQuestions(ctx, query)
+	if err != nil {
+		logger.Error("搜索问题失败",
+			slog.String("query", query),
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+	
+	logger.Info("问题搜索成功",
+		slog.String("query", query),
+		slog.Int("result_count", len(results)),
+	)
+	return results, nil
 }
 
 // IndexAllQuestions 从 QA Service 获取所有问题并建立索引
 func (s *searchService) IndexAllQuestions(ctx context.Context) error {
-	return s.store.IndexAllQuestions(ctx)
+	logger := log.FromContext(ctx)
+	
+	err := s.store.IndexAllQuestions(ctx)
+	if err != nil {
+		logger.Error("索引所有问题失败",
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Info("所有问题索引完成")
+	return nil
 }
 
 // DeleteIndexAllQuestions 删除所有问题索引并重新创建空索引
 func (s *searchService) DeleteIndexAllQuestions(ctx context.Context) error {
-	return s.store.DeleteIndexAllQuestions(ctx)
+	logger := log.FromContext(ctx)
+	
+	err := s.store.DeleteIndexAllQuestions(ctx)
+	if err != nil {
+		logger.Error("删除所有问题索引失败",
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	
+	logger.Info("所有问题索引已删除")
+	return nil
 }

--- a/cmd/search-service/main.go
+++ b/cmd/search-service/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 
 	"qahub/search-service/internal/handler"
 	"qahub/search-service/internal/service"
@@ -28,32 +29,59 @@ func main() {
 	if err := config.Init("configs"); err != nil {
 		log.Fatalf("初始化配置失败: %v", err)
 	}
+
 	// 初始化日志
 	logpkg.InitLogger(&config.Conf.Log)
+	logger := slog.Default()
 
 	serviceName := "search.SearchService"
+	logger.Info("搜索服务启动中...",
+		slog.String("service", "search-service"),
+		slog.String("grpc_port", config.Conf.Services.SearchService.GrpcPort),
+	)
+
 	// 初始化依赖并注入
 	qaServiceAddr := config.Conf.Services.Gateway.QaServiceEndpoint
+	logger.Info("初始化 Elasticsearch 存储...",
+		slog.String("qa_service_addr", qaServiceAddr),
+	)
 	esStore, err := store.NewEsStore(config.Conf.Elasticsearch, qaServiceAddr)
 	if err != nil {
+		logger.Error("初始化 Elasticsearch store 失败",
+			slog.String("error", err.Error()),
+		)
 		log.Fatalf("初始化 Elasticsearch store 失败: %v", err)
 	}
 	defer util.Cleanup("Elasticsearch client", esStore.Close)
+	logger.Info("Elasticsearch 连接成功")
+
+	logger.Info("初始化 Kafka 消费者...")
 	consumer := messaging.NewKafkaConsumer(config.Conf.Kafka, service.TopicQuestions, service.GroupID, nil)
 	searchService := service.NewSearchService(esStore)
 
 	// 注册事件处理器
 	consumer.SetHandlers(searchService.RegisterHandlers())
+	logger.Info("Kafka 消费者初始化成功")
 
 	searchHandler := handler.NewSearchServer(searchService)
 
 	// 初始化 user-service 的客户端连接
+	logger.Info("连接到 user-service...",
+		slog.String("endpoint", config.Conf.Services.Gateway.UserServiceEndpoint),
+	)
 	userClient, err := clients.NewUserServiceClient(config.Conf.Services.Gateway.UserServiceEndpoint)
 	if err != nil {
+		logger.Error("连接 user-service 失败",
+			slog.String("error", err.Error()),
+		)
 		log.Fatalf("无法连接到 user-service: %v", err)
 	}
+	logger.Info("user-service 连接成功")
 
 	// 创建并运行 gRPC 服务器
+	logger.Info("初始化 gRPC 服务器...",
+		slog.String("service_name", serviceName),
+	)
 	serverOpts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			interceptor.LogUnaryServerInterceptor(),
@@ -70,7 +98,13 @@ func main() {
 		consumer, esStore)
 
 	// 启动后台任务
+	logger.Info("启动 Kafka 消费者后台任务...")
 	go consumer.Start(context.Background())
+
+	logger.Info("搜索服务准备就绪，开始监听请求",
+		slog.String("grpc_port", config.Conf.Services.SearchService.GrpcPort),
+	)
+
 	grpcSrv.Run(func(s *grpc.Server) {
 		searchHandler.RegisterServer(s)
 	})

--- a/cmd/user-service/internal/handler/grpc_handler.go
+++ b/cmd/user-service/internal/handler/grpc_handler.go
@@ -2,9 +2,11 @@ package handler
 
 import (
 	"context"
+	"log/slog"
 
 	pb "qahub/api/proto/user"
 	"qahub/pkg/auth"
+	"qahub/pkg/log"
 	"qahub/user-service/internal/dto"
 	"qahub/user-service/internal/model"
 	"qahub/user-service/internal/service"
@@ -31,6 +33,13 @@ func NewUserGrpcServer(svc service.UserService) *UserGrpcServer {
 }
 
 func (s *UserGrpcServer) Register(ctx context.Context, req *pb.RegisterRequest) (*pb.RegisterResponse, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("用户注册请求",
+		slog.String("username", req.Username),
+		slog.String("email", req.Email),
+	)
+
 	userResponse, err := s.userService.Register(ctx, dto.RegisterRequest{
 		Username: req.Username,
 		Email:    req.Email,
@@ -38,8 +47,18 @@ func (s *UserGrpcServer) Register(ctx context.Context, req *pb.RegisterRequest) 
 		Password: req.Password,
 	})
 	if err != nil {
+		logger.Error("用户注册失败",
+			slog.String("username", req.Username),
+			slog.String("email", req.Email),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("用户注册成功",
+		slog.Int64("user_id", userResponse.ID),
+		slog.String("username", userResponse.Username),
+	)
 
 	return &pb.RegisterResponse{
 		User: &pb.User{
@@ -52,32 +71,76 @@ func (s *UserGrpcServer) Register(ctx context.Context, req *pb.RegisterRequest) 
 }
 
 func (s *UserGrpcServer) Login(ctx context.Context, req *pb.LoginRequest) (*pb.LoginResponse, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("用户登录请求",
+		slog.String("username", req.Username),
+	)
+
 	token, err := s.userService.Login(ctx, req.Username, req.Password)
 	if err != nil {
+		logger.Warn("用户登录失败",
+			slog.String("username", req.Username),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("用户登录成功",
+		slog.String("username", req.Username),
+	)
+
 	return &pb.LoginResponse{Token: token}, nil
 }
 
 func (s *UserGrpcServer) Logout(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	logger := log.FromContext(ctx)
+
 	// 从 context 中获取认证用户ID
 	identity, ok := auth.FromContext(ctx)
 	if !ok || identity.UserID == 0 {
+		logger.Error("登出失败：无法从context获取用户信息")
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
 
+	logger.Info("用户登出请求",
+		slog.Int64("user_id", identity.UserID),
+		slog.String("username", identity.Username),
+	)
+
 	err := s.userService.Logout(ctx, identity.Token, identity.Claims)
 	if err != nil {
+		logger.Error("用户登出失败",
+			slog.Int64("user_id", identity.UserID),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("用户登出成功",
+		slog.Int64("user_id", identity.UserID),
+	)
+
 	return &emptypb.Empty{}, nil
 }
 
 func (s *UserGrpcServer) ValidateToken(ctx context.Context, req *pb.ValidateTokenRequest) (*pb.ValidateTokenResponse, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Debug("Token 验证请求")
+
 	identity, err := s.userService.ValidateToken(ctx, req.JwtToken)
 	if err != nil {
+		logger.Warn("Token 验证失败",
+			slog.String("error", err.Error()),
+		)
 		return &pb.ValidateTokenResponse{}, nil
 	}
+
+	logger.Debug("Token 验证成功",
+		slog.Int64("user_id", identity.UserID),
+		slog.String("username", identity.Username),
+	)
 
 	// 将 jwt.MapClaims 转换为 map[string]string
 	claimsMap := make(map[string]*structpb.Value)
@@ -95,10 +158,25 @@ func (s *UserGrpcServer) ValidateToken(ctx context.Context, req *pb.ValidateToke
 }
 
 func (s *UserGrpcServer) GetUserProfile(ctx context.Context, req *pb.GetUserProfileRequest) (*pb.GetUserProfileResponse, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("获取用户资料请求",
+		slog.Int64("user_id", req.UserId),
+	)
+
 	userResponse, err := s.userService.GetUserProfile(ctx, req.UserId)
 	if err != nil {
+		logger.Error("获取用户资料失败",
+			slog.Int64("user_id", req.UserId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("获取用户资料成功",
+		slog.Int64("user_id", req.UserId),
+		slog.String("username", userResponse.Username),
+	)
 
 	return &pb.GetUserProfileResponse{
 		User: &pb.User{
@@ -112,14 +190,31 @@ func (s *UserGrpcServer) GetUserProfile(ctx context.Context, req *pb.GetUserProf
 }
 
 func (s *UserGrpcServer) UpdateUserProfile(ctx context.Context, req *pb.UpdateUserProfileRequest) (*emptypb.Empty, error) {
+	// 从 context 中获取 logger
+	logger := log.FromContext(ctx)
+
+	// 记录请求开始，包含关键输入参数
+	logger.Info("开始更新用户资料",
+		slog.Int64("target_user_id", req.UserId),
+		slog.String("new_username", req.Username),
+		slog.String("new_email", req.Email),
+	)
+
 	// 从 context 中获取认证用户ID
 	identity, ok := auth.FromContext(ctx)
 	if !ok || identity.UserID == 0 {
+		logger.Error("无法从context获取用户信息",
+			slog.Int64("target_user_id", req.UserId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
 
 	// 权限校验：确保用户只能更新自己的信息
 	if identity.UserID != req.UserId {
+		logger.Warn("权限校验失败：用户尝试更新他人资料",
+			slog.Int64("authenticated_user_id", identity.UserID),
+			slog.Int64("target_user_id", req.UserId),
+		)
 		return nil, status.Errorf(codes.PermissionDenied, "没有权限执行此操作")
 	}
 
@@ -130,30 +225,62 @@ func (s *UserGrpcServer) UpdateUserProfile(ctx context.Context, req *pb.UpdateUs
 		Bio:      req.Bio,
 	}
 
+	// 调用 service 层更新用户资料
 	err := s.userService.UpdateUserProfile(ctx, updateModel)
 	if err != nil {
+		logger.Error("更新用户资料失败",
+			slog.Int64("user_id", req.UserId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	// 记录成功日志
+	logger.Info("用户资料更新成功",
+		slog.Int64("user_id", req.UserId),
+		slog.String("username", req.Username),
+	)
 
 	return &emptypb.Empty{}, nil
 }
 
 func (s *UserGrpcServer) DeleteUser(ctx context.Context, req *pb.DeleteUserRequest) (*emptypb.Empty, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("删除用户请求",
+		slog.Int64("target_user_id", req.UserId),
+	)
+
 	// 从 context 中获取认证用户ID
 	identity, ok := auth.FromContext(ctx)
 	if !ok || identity.UserID == 0 {
+		logger.Error("删除用户失败：无法从context获取用户信息",
+			slog.Int64("target_user_id", req.UserId),
+		)
 		return nil, status.Errorf(codes.Internal, "无法从context获取用户信息")
 	}
 
 	// 权限校验：确保用户只能删除自己的账户
 	if identity.UserID != req.UserId {
+		logger.Warn("权限校验失败：用户尝试删除他人账户",
+			slog.Int64("authenticated_user_id", identity.UserID),
+			slog.Int64("target_user_id", req.UserId),
+		)
 		return nil, status.Errorf(codes.PermissionDenied, "没有权限执行此操作")
 	}
 
 	err := s.userService.DeleteUser(ctx, req.UserId)
 	if err != nil {
+		logger.Error("删除用户失败",
+			slog.Int64("user_id", req.UserId),
+			slog.String("error", err.Error()),
+		)
 		return nil, err
 	}
+
+	logger.Info("删除用户成功",
+		slog.Int64("user_id", req.UserId),
+	)
 
 	return &emptypb.Empty{}, nil
 }

--- a/cmd/user-service/main.go
+++ b/cmd/user-service/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"qahub/pkg/config"
 	"qahub/pkg/database"
 	"qahub/pkg/health"
@@ -27,25 +28,45 @@ func main() {
 
 	// 初始化日志
 	logpkg.InitLogger(&config.Conf.Log)
+	logger := slog.Default()
+
+	logger.Info("用户服务启动中...",
+		slog.String("service", "user-service"),
+		slog.String("grpc_port", cfg.GrpcPort),
+	)
 
 	// 初始化业务依赖 (DB, Redis, Store, Service, Handler)
 	serviceName := "user.UserService"
 
+	logger.Info("初始化数据库连接...")
 	db, err := database.NewMySQLConnection(config.Conf.MySQL)
 	if err != nil {
+		logger.Error("数据库连接失败",
+			slog.String("error", err.Error()),
+		)
 		log.Fatalf("Database connection failed: %v", err)
 	}
 	defer util.Cleanup("MySQL connection", db.Close)
+	logger.Info("数据库连接成功")
 
+	logger.Info("初始化 Redis 连接...")
 	redisClient, err := redis.NewClient(config.Conf.Redis)
 	if err != nil {
+		logger.Error("Redis 连接失败",
+			slog.String("error", err.Error()),
+		)
 		log.Fatalf("Redis connection failed: %v", err)
 	}
 	defer util.Cleanup("Redis client", redisClient.Close)
+	logger.Info("Redis 连接成功")
 
 	userStore := store.NewUserCacheStore(redisClient, store.NewMySQLUserStore(db))
 	userService := service.NewUserService(userStore)
 	userHandler := handler.NewUserGrpcServer(userService)
+
+	logger.Info("初始化 gRPC 服务器...",
+		slog.String("service_name", serviceName),
+	)
 
 	// 创建服务器
 	serverOpts := []grpc.ServerOption{
@@ -64,6 +85,11 @@ func main() {
 		healthUpdater,
 		serviceName,
 		userStore)
+
+	logger.Info("用户服务准备就绪，开始监听请求",
+		slog.String("grpc_port", cfg.GrpcPort),
+	)
+
 	// 运行服务器，并传入业务注册的逻辑
 	grpcSrv.Run(func(s *grpc.Server) {
 		userHandler.RegisterServer(s)

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -8,9 +8,9 @@ server:
 log:
   level: "info"
   format: "json"
-  Output: "stdout"
-  addSource: True
-  initialFields:
+  output: "stdout"
+  add_source: True
+  initial_fields:
     service: "qahub"
     environment: "docker"
   file:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -8,9 +8,9 @@ server:
 log:
   level: "info"
   format: "json"
-  Output: "stdout"
-  addSource: True
-  initialFields:
+  output: "stdout"
+  add_source: True
+  initial_fields:
     service: "qahub"
     environment: "docker"
   file:


### PR DESCRIPTION
## 概述

本 PR 为 QAHub 微服务项目添加了全面的结构化日志系统，使用 Go 标准库 \`log/slog\` 实现。从初始化层（main.go）到处理层（handler）再到业务层（service），确保所有关键操作都有适当的日志覆盖。

## 变更概览

### 1. 服务初始化层（main.go）
为所有 4 个微服务的初始化过程添加日志。

### 2. gRPC 处理器层（handler）
为所有服务的 gRPC 处理器方法添加日志。

### 3. 业务服务层（service）
为关键业务逻辑添加日志（采用 '关键路径优先' 策略）。

## 提交历史
- feat(service): 为 notification-service 和 search-service 的 service 层添加关键业务日志
- feat(service): 为 qa-service 的 service 层添加关键业务日志
- feat(service): 为 user-service 的 service 层添加关键业务日志
- fix: 修复配置文件 YAML 格式和 Dockerfile
- feat(handler): 为所有服务的 gRPC handler 添加结构化日志
- feat(main): 为所有服务的 main.go 添加结构化日志